### PR TITLE
Docs: Fix Classname Typo

### DIFF
--- a/website/src/pages/docs/transforms/filtering.mdx
+++ b/website/src/pages/docs/transforms/filtering.mdx
@@ -22,7 +22,7 @@ import { FilterTypes } from '@graphql-tools/wrap'
 const subschema = {
   schema,
   executor,
-  transforms: [new FilterType(namedType => !namedType.endsWith('_Secret'))]
+  transforms: [new FilterTypes(namedType => !namedType.endsWith('_Secret'))]
 }
 ```
 


### PR DESCRIPTION
This PR fixes an example in the docs that uses `FilterType` instead of `FilterTypes`.