### PR TITLE
fix: send Authorizatoin header as an object in the examples

### DIFF
--- a/examples/combining-local-and-remote-schemas/src/gateway.ts
+++ b/examples/combining-local-and-remote-schemas/src/gateway.ts
@@ -13,15 +13,21 @@ async function makeGatewaySchema() {
   // these are simple functions that query a remote GraphQL API for JSON.
   const productsExec = buildHTTPExecutor({
     endpoint: 'http://localhost:4001/graphql',
-    headers: executorRequest => executorRequest?.context?.authHeader,
+    headers: executorRequest => ({
+      Authorization: executorRequest?.context?.authHeader,
+    }),
   });
   const storefrontsExec = buildHTTPExecutor({
     endpoint: 'http://localhost:4002/graphql',
-    headers: executorRequest => executorRequest?.context?.authHeader,
+    headers: executorRequest => ({
+      Authorization: executorRequest?.context?.authHeader,
+    }),
   });
   const rainforestApiExec = buildHTTPExecutor({
     endpoint: 'http://localhost:4001/graphql',
-    headers: executorRequest => executorRequest?.context?.authHeader,
+    headers: executorRequest => ({
+      Authorization: executorRequest?.context?.authHeader,
+    }),
   });
   const adminContext = { authHeader: 'Bearer my-app-to-app-token' };
 


### PR DESCRIPTION
The examples of [Combining local and remote schemas
](https://the-guild.dev/graphql/stitching/handbook/foundation/combining-local-and-remote-schemas) seem not to send authorization headers properly.

I've edited the sample code to follow the tutorial as follows:

```js
// the code mentioned in the tutorial
buildHTTPExecutor({
  endpoint: 'http://localhost:4001/graphql',
  headers({ context }) {
    return {
      Authorization: context.authHeader
    }
  }
})

// the edit I made in this PR
const productsExec = buildHTTPExecutor({
  endpoint: 'http://localhost:4001/graphql',
  headers: executorRequest => ({
    Authorization: executorRequest?.context?.authHeader  // send an object instead of `authHeader` directly
  }),
});
```

If I should create an issue first, please let me know.

Thanks in advance!