### PR TITLE
Fix example inconsistency in Type Merging documentation

### DIFF
--- a/website/src/content/docs/approaches/type-merging.mdx
+++ b/website/src/content/docs/approaches/type-merging.mdx
@@ -184,10 +184,10 @@ that gets resolved as the local `User` type.
 ### Null Records
 
 The above example will always resolve a stubbed `User` record for _any_ requested ID. For example,
-requesting ID `7` (which has no associated posts) would return:
+requesting ID `8` (which has no associated posts) would return:
 
 ```json
-{ "id": "7", "posts": [] }
+{ "id": "8", "posts": [] }
 ```
 
 This fabricated record fulfills the not-null requirement of the `posts:[Post]!` field. However, it


### PR DESCRIPTION
Hello,

Problem: The “Null Records” example demonstrates a `postUserById(id: "7")` query returning `{ id: "7", posts: [] }`, but the provided `postsData` includes a post with `authorId: "7"`. This creates a contradiction between the sample data and described behavior.

Fix: The documentation has been updated to use `id: "8"` instead of `id: "7"` in the Null Records example. This ensures that the example aligns with the provided `postsData`, where no posts exist for `authorId: "8"`.

Thank you for reviewing this update!