### PR TITLE
fix: correct server port in storefronts service log message

### DIFF
--- a/examples/combining-local-and-remote-schemas/src/services/storefronts/index.ts
+++ b/examples/combining-local-and-remote-schemas/src/services/storefronts/index.ts
@@ -8,4 +8,4 @@ const yoga = createYoga({
 
 const server = createServer(yoga);
 
-server.listen(4002, () => console.log('storefronts  running at http://localhost:4001/graphql'));
+server.listen(4002, () => console.log('storefronts  running at http://localhost:4002/graphql'));


### PR DESCRIPTION
Fixes #979 

There is a little missleading typo in storefronts

```
server.listen(4002, () => console.log('storefronts  running at http://localhost:4001/graphql'));
```

should be
```
server.listen(4002, () => console.log('storefronts  running at http://localhost:4002/graphql'));
```