### PR TITLE
fix(ruby): address review feedback for example server

### DIFF
--- a/examples/subservice-languages/ruby/lib/graphql_server.rb
+++ b/examples/subservice-languages/ruby/lib/graphql_server.rb
@@ -19,12 +19,27 @@ class GraphQLServer
   def call(env)
     req = Rack::Request.new(env)
     body = req.body.read
-    req_vars = body.empty? ? {} : JSON.parse(body)
+
+    begin
+      req_vars = body.empty? ? {} : JSON.parse(body)
+    rescue JSON::ParserError
+      return error_response(400, 'Request body must be valid JSON')
+    end
+
+    query = req_vars['query']
+    return error_response(400, 'GraphQL query is required') if query.nil? || query.empty?
+
     result = schema.execute(
-      req_vars['query'],
+      query,
       operation_name: req_vars['operationName'],
       variables: req_vars['variables'] || {},
     )
     [200, { 'content-type' => 'application/json' }, [JSON.dump(result.to_h)]]
+  end
+
+  private
+
+  def error_response(status, message)
+    [status, { 'content-type' => 'application/json' }, [JSON.dump({ errors: [{ message: message }] })]]
   end
 end

--- a/examples/subservice-languages/ruby/lib/graphql_server.rb
+++ b/examples/subservice-languages/ruby/lib/graphql_server.rb
@@ -27,7 +27,9 @@ class GraphQLServer
     end
 
     query = req_vars['query']
-    return error_response(400, 'GraphQL query is required') if query.nil? || query.empty?
+    unless query.is_a?(String) && !query.strip.empty?
+      return error_response(400, 'GraphQL query is required')
+    end
 
     result = schema.execute(
       query,

--- a/examples/subservice-languages/ruby/services/products.rb
+++ b/examples/subservice-languages/ruby/services/products.rb
@@ -61,5 +61,8 @@ module DefaultResolver
 end
 
 schema = GraphQL::Schema.from_definition(type_defs, default_resolve: DefaultResolver)
+schema.directive(MergeDirective)
+schema.directive(KeyDirective)
+schema.directive(ComputedDirective)
 
 GraphQLServer.run(schema, Port: 4002)

--- a/examples/subservice-languages/ruby/tests/ruby.test.ts
+++ b/examples/subservice-languages/ruby/tests/ruby.test.ts
@@ -15,12 +15,8 @@ describe('Ruby subservices', () => {
       cwd: baseDir,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    servicesProcess.stdout?.on('data', (chunk: Buffer) => {
-      process.stdout.write(chunk);
-    });
-    servicesProcess.stderr?.on('data', (chunk: Buffer) => {
-      process.stderr.write(chunk);
-    });
+    servicesProcess.stdout?.pipe(process.stdout, { end: false });
+    servicesProcess.stderr?.pipe(process.stderr, { end: false });
   }, 120_000);
   afterAll(async () => {
     servicesProcess?.kill('SIGTERM');

--- a/examples/subservice-languages/ruby/tests/ruby.test.ts
+++ b/examples/subservice-languages/ruby/tests/ruby.test.ts
@@ -15,6 +15,9 @@ describe('Ruby subservices', () => {
       cwd: baseDir,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    servicesProcess.stdout?.on('data', (chunk: Buffer) => {
+      process.stdout.write(chunk);
+    });
     servicesProcess.stderr?.on('data', (chunk: Buffer) => {
       process.stderr.write(chunk);
     });


### PR DESCRIPTION
## Summary
- Addresses Copilot review comments from #1829
- Registers stitching directive classes on the products `from_definition` schema
- Drains service process stdout to avoid pipe-buffer hangs
- Returns clear `400` JSON errors for invalid JSON / missing query

## Test plan
- [x] `yarn test examples/subservice-languages/ruby/tests/ruby.test.ts --runInBand --forceExit`
- [ ] CI unit job green


Made with [Cursor](https://cursor.com)